### PR TITLE
`Movable::scale()` now accepts 2 multiplier arguments

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -92,10 +92,21 @@ int main()
         }
         else if (command.name == "scale") {
             // Move the nth shape in the plane to a given position.
-            if (!command.hasArguments(2)) { continue; }
-            int index = stoi(command.arguments.at(0));
-            float multiplier = stof(command.arguments.at(1));
-            plane->scaleShape(index, multiplier);
+            int index;
+            float xMultiplier;
+            float yMultiplier;
+            if (command.hasArguments(2)) {
+                index = stoi(command.arguments.at(0));
+                xMultiplier = stof(command.arguments.at(1));
+                yMultiplier = xMultiplier;
+            }
+            else if (command.hasArguments(3)) {
+                index = stoi(command.arguments.at(0));
+                xMultiplier = stof(command.arguments.at(1));
+                yMultiplier = stof(command.arguments.at(2));
+            }
+            else { continue; }
+            plane->scaleShape(index, xMultiplier, yMultiplier);
             cout << "Scaled shape!" << endl;
         }
         else if (command.name == "move") {

--- a/src/shapes/movable/movable.h
+++ b/src/shapes/movable/movable.h
@@ -9,7 +9,7 @@ public:
     /// Mutates the shape's private _leftTop and _points fields.
     virtual void move(Point *newLeftTop) = 0;
     /// Mutates the shape's size by multiplying its current size with a given multiplier.
-    virtual void scale(float multiplier) = 0;
+    virtual void scale(float xMultiplier, float yMultiplier) = 0;
 };
 
 

--- a/src/shapes/plane/plane.cpp
+++ b/src/shapes/plane/plane.cpp
@@ -21,8 +21,8 @@ void Plane::moveShape(int index, Point* newPos) {
     dynamic_cast<Movable*>(this->_shapes.at(index-1))->move(newPos);
 }
 
-void Plane::scaleShape(int index, float multiplier) {
-    dynamic_cast<Movable*>(this->_shapes.at(index-1))->scale(multiplier);
+void Plane::scaleShape(int index, float xMultiplier, float yMultiplier) {
+    dynamic_cast<Movable *>(this->_shapes.at(index-1))->scale(xMultiplier, -1);
 }
 
 string Plane::getInfo(int index) {

--- a/src/shapes/plane/plane.h
+++ b/src/shapes/plane/plane.h
@@ -16,7 +16,7 @@ public:
     /// Moves the nth shape to a new location on the plane.
     void moveShape(int index, Point* newPos);
     /// Scales the nth shape on the plane by a given multiplier.
-    void scaleShape(int index, float multiplier);
+    void scaleShape(int index, float xMultiplier, float yMultiplier);
     /// Gets detailed information on the nth shape on the plane.
     string getInfo(int index);
 private:

--- a/src/shapes/square/square.cpp
+++ b/src/shapes/square/square.cpp
@@ -12,8 +12,8 @@ Square::Square(Point* leftTop, float size)
     calculatePoints();
 }
 
-void Square::scale(float multiplier) {
-    this->_edge *= multiplier;
+void Square::scale(float xMultiplier, float yMultiplier) {
+    this->_edge *= xMultiplier;
     calculatePoints();
     calculateArea();
     calculatePerimeter();

--- a/src/shapes/square/square.h
+++ b/src/shapes/square/square.h
@@ -10,7 +10,7 @@ public:
     /// Creates a new square from a position and size.
     Square(Point* leftTop, float size);
     void move(Point *newLeftTop) override;
-    void scale(float multiplier) override;
+    void scale(float xMultiplier, float yMultiplier) override;
     void calculateArea() override;
     void calculatePerimeter() override;
     void calculatePoints() override;


### PR DESCRIPTION
- Refactored `Square::scale()` to have 2 multiplier parameters
- Refactored `plane::scaleShape()` to have 2 multiplier parameters
- Refactored `movable::scale()` to have 2 multiplier parameters
- "Scale" command adjusted to accept 1 or 2 scale multipliers
